### PR TITLE
[FEAT] Generate SignUp target

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Modules.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Modules.swift
@@ -30,6 +30,7 @@ public extension ModulePath {
 public extension ModulePath {
     enum Feature: String, CaseIterable {
         case SignIn
+        case SignUp
         
         public static let name: String = "Feature"
     }

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -14,7 +14,8 @@ let targets: [Target] = [
         factory: .init(
             dependencies: [
                 .domain,
-                .feature(implements: .SignIn)
+                .feature(implements: .SignIn),
+                .feature(implements: .SignUp)
             ]
         )
     )

--- a/Projects/Feature/SignUp/Interface/Sources/source.swift
+++ b/Projects/Feature/SignUp/Interface/Sources/source.swift
@@ -1,0 +1,1 @@
+// this is for tuist

--- a/Projects/Feature/SignUp/Project.swift
+++ b/Projects/Feature/SignUp/Project.swift
@@ -1,0 +1,32 @@
+//
+//  Project.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 강민성 on 11/6/23.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePath.Feature.name+ModulePath.Feature.SignUp.rawValue,
+    targets: [
+        .feature(
+            interface: .SignUp,
+            factory: .init(
+                dependencies: [
+                    .domain
+                ]
+            )
+        ),
+        .feature(
+            implements: .SignUp,
+            factory: .init(
+                dependencies: [
+                    .feature(interface: .SignUp)
+                ]
+            )
+        )
+    ]
+)

--- a/Projects/Feature/SignUp/Sources/source.swift
+++ b/Projects/Feature/SignUp/Sources/source.swift
@@ -1,0 +1,1 @@
+// this is for tuist


### PR DESCRIPTION
## [#11] [FEAT] : Generate SignUp target

## 🌱 작업한 내용

- SignUp (회원가입) 타겟을 만들었습니다.
- 이후 develop 브랜치에서 pull 하고 난 뒤에 반드시 make clean -> tuist clean -> tuist fetch -> tuist generate 하셔야합니다

## 🌱 PR Point

- 타겟을 만드는 과정을 살펴보시면 됩니다

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ex. 로그인 화면 | 파일첨부바람 |

## 📮 관련 이슈

- Resolved: #11 
