### PR TITLE
[#15] [FEAT] : 로그인 화면 레이아웃 그리기 

### DIFF
--- a/Projects/Feature/SignIn/Sources/SignInView.swift
+++ b/Projects/Feature/SignIn/Sources/SignInView.swift
@@ -1,0 +1,133 @@
+//
+//  SignInView.swift
+//  FeatureSignIn
+//
+//  Created by 강민성 on 11/6/23.
+//
+
+import UIKit
+import Shared
+import SnapKit
+import AuthenticationServices
+
+class SignInView: UIView {
+    
+    var firstLabel: UILabel = {
+       var label = UILabel()
+        label.text = "퇴근하고 뭐하지?"
+        label.textAlignment = .center
+        return label
+    }()
+    
+    var secondLabel: UILabel = {
+       var label = UILabel()
+        label.text = "직장인 갓생"
+        label.textAlignment = .center
+        return label
+    }()
+    
+    var thirdLabel: UILabel = {
+        var label = UILabel()
+        label.text = "가치있는 정보가 모이는 직갓생에서\n당신의 직장인 커뮤니티를 시작해보세요"
+        label.textAlignment = .center
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    var signInWithKakaoButton: UIButton = {
+       var button = UIButton()
+        button.backgroundColor = .yellow
+        button.setTitle("카카오톡으로 계속하기", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        return button
+    }()
+    
+    let signInWithAppleButton = ASAuthorizationAppleIDButton(type: .signIn, style: .white)
+    
+    var continueWithEmailButton: UIButton = {
+        var button = UIButton()
+        button.setTitle("이메일로 계속하기", for: .normal)
+        button.setUnderline()
+        return button
+    }()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        render()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func render() {
+        addSubview(firstLabel)
+        addSubview(secondLabel)
+        addSubview(thirdLabel)
+        addSubview(signInWithKakaoButton)
+        addSubview(signInWithAppleButton)
+        addSubview(continueWithEmailButton)
+        
+        firstLabel.snp.makeConstraints { make in
+            make.width.equalTo(335)
+            make.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            make.top.equalTo(safeAreaLayoutGuide.snp.top).offset(136)
+        }
+        
+        secondLabel.snp.makeConstraints { make in
+            make.width.equalTo(335)
+            make.height.equalTo(52)
+            make.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            make.top.equalTo(firstLabel.snp.bottom)
+            
+        }
+        
+        thirdLabel.snp.makeConstraints { make in
+            make.width.equalTo(335)
+            make.height.equalTo(48)
+            make.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            make.top.equalTo(secondLabel.snp.bottom).offset(16)
+        }
+        
+        signInWithKakaoButton.snp.makeConstraints { make in
+            make.width.equalTo(335)
+            make.height.equalTo(52)
+            make.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            make.top.equalTo(thirdLabel.snp.bottom).offset(80)
+        }
+        
+        signInWithAppleButton.snp.makeConstraints { make in
+            make.width.equalTo(335)
+            make.height.equalTo(52)
+            make.leading.equalTo(safeAreaLayoutGuide.snp.leading).offset(20)
+            make.trailing.equalTo(safeAreaLayoutGuide.snp.trailing).offset(-20)
+            make.top.equalTo(signInWithKakaoButton.snp.bottom).offset(16)
+        }
+        
+        continueWithEmailButton.snp.makeConstraints { make in
+            make.width.equalTo(115)
+            make.height.equalTo(24)
+            make.centerX.equalTo(safeAreaLayoutGuide.snp.centerX)
+            make.top.equalTo(signInWithAppleButton.snp.bottom).offset(24)
+        }
+
+    }
+
+}
+
+extension UIButton {
+    func setUnderline() {
+        guard let title = title(for: .normal) else { return }
+        let attributedString = NSMutableAttributedString(string: title)
+        attributedString.addAttribute(.underlineStyle,
+                                      value: NSUnderlineStyle.single.rawValue,
+                                      range: NSRange(location: 0, length: title.count)
+        )
+        setAttributedTitle(attributedString, for: .normal)
+    }
+}

--- a/Projects/Feature/SignIn/Sources/SignInViewController.swift
+++ b/Projects/Feature/SignIn/Sources/SignInViewController.swift
@@ -1,0 +1,27 @@
+//
+//  SignInViewController.swift
+//  FeatureSignIn
+//
+//  Created by 강민성 on 11/6/23.
+//
+
+import UIKit
+import Shared
+
+public class SignInViewController: UIViewController {
+    
+    var signInView = SignInView()
+    
+    public override func loadView() {
+        super.loadView()
+        view = signInView
+    }
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+
+}

--- a/Projects/Feature/SignIn/Sources/source.swift
+++ b/Projects/Feature/SignIn/Sources/source.swift
@@ -1,1 +1,0 @@
-// This is for tuist


### PR DESCRIPTION
## [#15] [FEAT] : 로그인 화면 레이아웃 그리기 

## 🌱 작업한 내용

- 로그인 화면 레이아웃을 그렸습니다
- SignInView 를 생성하여 loadview를 통해서 불러오고, SnapKit을 통해서 render하였습니다
- 현재 addSubview 함수를 여러번 쓰는데, addSubviews 라는 함수를 만들어서 배열에 뷰들을 넣어서 추가하는 방식으로 전환할 예정입니다.
- Tuist에 필요한 목업 파일을 삭제하였습니다

## 🌱 PR Point

- 뷰에서 레이아웃을 담당하는 함수를 render로 통일할생각입니다.
- SceneDelegate는 각자 시뮬레이터를 돌리는데 건들일거같아서 원본 상태로 바꿔놨습니다. 여러분들도 커밋전에 SceneDelegate를 원본 상태로 돌려주세요.
- 코드리뷰를 반드시 해주세요.


## 📮 관련 이슈

- Resolved: #15 
