### PR TITLE
[#39][FEAT] Multi-Filter-Chips Component 생성, Basic-Filter-Chips Component 생성

### DIFF
--- a/Projects/App/Sources/Application/SceneDelegate.swift
+++ b/Projects/App/Sources/Application/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Feature
+import FeatureProfile
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -21,6 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(frame:UIScreen.main.bounds)
         window?.windowScene = windowscene
         
+       
         window?.makeKeyAndVisible()
     }
     

--- a/Projects/Feature/Profile/Sources/profileMainViewController.swift
+++ b/Projects/Feature/Profile/Sources/profileMainViewController.swift
@@ -10,6 +10,8 @@ import SnapKit
 import RxSwift
 
 
+
+
 public class ProgressBarView: UIView {
     var profileProgressView: UIProgressView = {
         let view = UIProgressView()
@@ -23,6 +25,9 @@ public class ProgressBarView: UIView {
 
 public class profileMainViewController: UIViewController, UITextFieldDelegate {
 
+    
+    
+    
     let nickNameLabel = UILabel()
     
     
@@ -44,7 +49,7 @@ public class profileMainViewController: UIViewController, UITextFieldDelegate {
     
     public override func viewDidLoad() {
         
-        
+       
         let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
         self.navigationItem.backBarButtonItem = backBarButtonItem
         nextBtn.isEnabled = false
@@ -99,6 +104,7 @@ public class profileMainViewController: UIViewController, UITextFieldDelegate {
         nickNameView.addSubview(nickNameLabel)
         view.addSubview(nickNameView)
        
+
         
         nickNameInputTextField.frame.size.height = 50
         nickNameView.addSubview(nickNameInputTextField)
@@ -137,6 +143,8 @@ public class profileMainViewController: UIViewController, UITextFieldDelegate {
     
     // 뷰 constraint 설정
     func render() {
+       
+        
         nickNameLabel.snp.makeConstraints{ make in
             make.top.equalToSuperview().offset(60)
             make.leading.equalToSuperview().offset(20)
@@ -165,6 +173,7 @@ public class profileMainViewController: UIViewController, UITextFieldDelegate {
             make.centerX.equalToSuperview()
             make.width.equalToSuperview()
         }
+    
     }
 }
 

--- a/Projects/Shared/DSKit/Sources/Components/TPBasicFilterChips.swift
+++ b/Projects/Shared/DSKit/Sources/Components/TPBasicFilterChips.swift
@@ -1,0 +1,58 @@
+//
+//  TPBasicFilterChips.swift
+//  SharedDSKit
+//
+//  Created by yoonyeosong on 2023/11/19.
+//
+
+import UIKit
+
+class TPBasicFilterChips: UIView {
+    public var smallEnabledChips: UIButton = {
+        var chips = UIButton()
+        
+        chips.layer.cornerRadius = 20
+        chips.backgroundColor = SharedDSKitAsset.Colors.bgGray.color
+        chips.setTitleColor(SharedDSKitAsset.Colors.gr100.color, for: .normal)
+        chips.titleLabel?.font = Fonts.Caption.font
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        chips.semanticContentAttribute = .forceRightToLeft
+        return chips
+    }()
+    public var smallActiveChips: UIButton = {
+        var chips = UIButton()
+        
+        chips.layer.cornerRadius = 20
+        chips.backgroundColor = SharedDSKitAsset.Colors.lightGreen.color
+        chips.setTitleColor(SharedDSKitAsset.Colors.white.color, for: .normal)
+        chips.titleLabel?.font = Fonts.ST01.font
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        chips.semanticContentAttribute = .forceRightToLeft
+        return chips
+    }()
+    public var largeEnabledChips: UIButton = {
+        var chips = UIButton()
+        
+        chips.layer.cornerRadius = 20
+        chips.backgroundColor = SharedDSKitAsset.Colors.bgGray.color
+        chips.setTitleColor(SharedDSKitAsset.Colors.gr100.color, for: .normal)
+        chips.titleLabel?.font = Fonts.SH01.font
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        chips.semanticContentAttribute = .forceRightToLeft
+        return chips
+        
+    }()
+    
+    public var largeActiveChips: UIButton = {
+        var chips = UIButton()
+        
+        chips.layer.cornerRadius = 20
+        chips.backgroundColor = SharedDSKitAsset.Colors.lightGreen.color
+        chips.setTitleColor(SharedDSKitAsset.Colors.white.color, for: .normal)
+        chips.titleLabel?.font = Fonts.SH01.font
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
+        chips.semanticContentAttribute = .forceRightToLeft
+        
+        return chips
+    }()
+}

--- a/Projects/Shared/DSKit/Sources/Components/TPMultiFilterChips.swift
+++ b/Projects/Shared/DSKit/Sources/Components/TPMultiFilterChips.swift
@@ -1,0 +1,45 @@
+//
+//  TPMultiFilterChips.swift
+//  SharedDSKit
+//
+//  Created by yoonyeosong on 2023/11/17.
+//
+
+import UIKit
+
+public class TPMultiFilterChips: UIView {
+    
+
+    public var enabledChips: UIButton = { //active되지 않았을 때, 다중선택 가능
+        
+        var chips = UIButton()
+        
+        chips.layer.cornerRadius = 20
+        chips.layer.borderColor = SharedDSKitAsset.Colors.gr10.color.cgColor
+        chips.layer.borderWidth = 1
+      
+        chips.setTitleColor(SharedDSKitAsset.Colors.gr100.color, for: .normal)
+        chips.titleLabel?.font = Fonts.SH01.font
+
+        chips.imageView?.contentMode = .scaleAspectFit
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
+        
+        return chips
+    }()
+    
+    public var activeChips: UIButton = { //active되었을 때, 다중선택 가능
+        var chips = UIButton()
+        chips.layer.cornerRadius = 20
+        chips.layer.borderColor = SharedDSKitAsset.Colors.lightGreen.color.cgColor
+        chips.layer.borderWidth = 1
+        
+        chips.setTitleColor(SharedDSKitAsset.Colors.green.color, for: .normal)
+        chips.titleLabel?.font = Fonts.SH01Bold.font
+        
+        chips.imageView?.contentMode = .scaleAspectFit
+        chips.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
+        
+        return chips
+        
+    }()
+}


### PR DESCRIPTION
## [#39] [FEAT] : Multi-Filter-Chips Component 생성

## 🌱 작업한 내용

- Multi-Filter-Chips의 Enabled chips Component생성
- Multi-Filter-Chips의 Active chips Component생성
- Baisc-Filter-Chips의 Enabled chips Component생성
- Basic-Filter-Chips의 Active chips Component생성

## 🌱 PR Point

- chips의 모양, 테두리, 컬러 Component화 진행
- title과 image는 공용 Component를 불러온 후, 보통 버튼 처럼 setTitle(), setImage() 함수를 사용해서 직접 설정.
- Baisc-Filtet-Chips에서 large Chip에 이미지-라벨-이미지 순으로 버튼이 구성되어 있는데 이미지 2개 들어간 것은 좀 더 연구해보겠습니다.(현재 라벨-이미지)로만 구현

## 📸 스크린샷

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| ex. 로그인 화면 | 파일첨부바람 |

## 📮 관련 이슈

- 없음.
